### PR TITLE
[DOCS] Alternative classification training advice

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -31,18 +31,22 @@ about field selection, see the
 [[dfa-classification-supervised]]
 ==== Training the {classification} model
 
-{classification-cap} – just like {regression} – is a supervised {ml} process. It 
-means that you need to supply a labeled training data set that has a {depvar} 
-and some fields that are related to it. The {classification} algorithm learns 
-the relationships between these fields and the {depvar}. Once you’ve trained the 
-model on your training data set, you can reuse the knowledge that the model has 
-learned about the relationships between the data points to classify new data.
+{classification-cap} – just like {regression} – is a supervised {ml} process.
+When you create the {dfanalytics-job}, you must provide a data set that contains
+the _ground truth_. That is to say, your data set must contain the {depvar} 
+and the {feature-vars} fields that are related to it. You can divide the data
+set into training and testing data by specifying a `training_percent`. By
+default when you use the <<put-dfanalytics,create {dfanalytics-jobs} API>>, 100%
+of the eligible documents in the data set are used for training. If you divide
+your data set, the job stratifies the data to ensure that both the training and
+testing data sets are representative of the full data set. That is to say, the
+same proportions of each class are fairly represented in both data sets.
 
-The effects of imbalanced data are automatically mitigated before the 
-training. Nonetheless, it is a good idea to train your model with a data set 
-that is approximately balanced. That is to say, ideally your data set should 
-have a similar number of data points for each class.
-
+When you are collecting a data set to train your model, ensure that it
+captures information for all of the classes. If some classes are poorly
+represented in the training data set, the model might be unaware of them. In
+general, complex decision boundaries between classes are harder to learn and
+require more data points per class in the training data.
 
 [discrete]
 [[dfa-classification-algorithm]]
@@ -145,12 +149,12 @@ You can measure how well the model has performed on your data set by using the
 {ref}/evaluate-dfanalytics.html[evaluate {dfanalytics} API]. The metric that the 
 evaluation provides you is a confusion matrix. The more classes you have, the 
 more complex the confusion matrix is. The matrix tells you how many data points 
-that belong to a given class were classified correctly and incorrectly.
+that belong to a given class were classified correctly and incorrectly. You can
+also view this matrix in {kib}.
 
 Another crucial measurement is how well your model performs on unseen data 
 points. To assess how well the trained model will perform on data it has never 
-seen before, you must set aside a proportion of the training data set for 
-testing. This split of the data set is the _testing data set_. Once the model has 
-been trained, you can let the model predict the value of the data points it has 
-never seen before and compare the prediction to the actual value by using the 
-evaluate {dfanalytics} API.
+seen before, you must set aside a proportion of your data as the
+_testing data set_. Once the model has been trained, you can let the model
+predict the value of the data points it has never seen before and compare the
+prediction to the actual value. See <<ml-dfanalytics-evaluate>>.

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -36,11 +36,12 @@ When you create the {dfanalytics-job}, you must provide a data set that contains
 the _ground truth_. That is to say, your data set must contain the {depvar} 
 and the {feature-vars} fields that are related to it. You can divide the data
 set into training and testing data by specifying a `training_percent`. By
-default when you use the <<put-dfanalytics,create {dfanalytics-jobs} API>>, 100%
-of the eligible documents in the data set are used for training. If you divide
-your data set, the job stratifies the data to ensure that both the training and
-testing data sets are representative of the full data set. That is to say, the
-same proportions of each class are fairly represented in both data sets.
+default when you use the
+{ref}put-dfanalytics.html[create {dfanalytics-jobs} API], 100% of the eligible
+documents in the data set are used for training. If you divide your data set,
+the job stratifies the data to ensure that both the training and testing data
+sets are representative of the full data set. That is to say, the same
+proportions of each class are fairly represented in both data sets.
 
 When you are collecting a data set to train your model, ensure that it
 captures information for all of the classes. If some classes are poorly
@@ -59,7 +60,6 @@ The effects of imbalanced data are automatically mitigated before the
 training. Nonetheless, it is a good idea to train your model with a data set 
 that is approximately balanced. That is to say, ideally your data set should 
 have a similar number of data points for each class.
-
 ////
 
 [discrete]
@@ -170,3 +170,13 @@ well your model performs on data it has never seen before and compare the
 prediction to the actual value.
 
 For more information, see <<ml-dfanalytics-evaluate>>.
+
+////
+Another crucial measurement is how well your model performs on unseen data
+points. To assess how well the trained model will perform on data it has never
+seen before, you must set aside a proportion of the training data set for 
+testing. This split of the data set is the _testing data set_. Once the model has 
+been trained, you can let the model predict the value of the data points it has 
+never seen before and compare the prediction to the actual value by using the 
+evaluate {dfanalytics} API.
+////

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -149,12 +149,10 @@ You can measure how well the model has performed on your data set by using the
 {ref}/evaluate-dfanalytics.html[evaluate {dfanalytics} API]. The metric that the 
 evaluation provides you is a confusion matrix. The more classes you have, the 
 more complex the confusion matrix is. The matrix tells you how many data points 
-that belong to a given class were classified correctly and incorrectly. You can
-also view this matrix in {kib}.
+that belong to a given class were classified correctly and incorrectly.
 
-Another crucial measurement is how well your model performs on unseen data 
-points. To assess how well the trained model will perform on data it has never 
-seen before, you must set aside a proportion of your data as the
-_testing data set_. Once the model has been trained, you can let the model
-predict the value of the data points it has never seen before and compare the
-prediction to the actual value. See <<ml-dfanalytics-evaluate>>.
+If you split your data set into training and testing data, you can determine how
+well your model performs on data it has never seen before and compare the
+prediction to the actual value.
+
+For more information, see <<ml-dfanalytics-evaluate>>.

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -48,6 +48,20 @@ represented in the training data set, the model might be unaware of them. In
 general, complex decision boundaries between classes are harder to learn and
 require more data points per class in the training data.
 
+////
+It means that you need to supply a labeled training data set that has a {depvar} 
+and some fields that are related to it. The {classification} algorithm learns 
+the relationships between these fields and the {depvar}. Once you’ve trained the 
+model on your training data set, you can reuse the knowledge that the model has 
+learned about the relationships between the data points to classify new data.
+
+The effects of imbalanced data are automatically mitigated before the 
+training. Nonetheless, it is a good idea to train your model with a data set 
+that is approximately balanced. That is to say, ideally your data set should 
+have a similar number of data points for each class.
+
+////
+
 [discrete]
 [[dfa-classification-algorithm]]
 ===== {classification-cap} algorithms


### PR DESCRIPTION
This PR depends on https://github.com/elastic/stack-docs/pull/973. It is a draft of alternative text for the training guidance on classification jobs.